### PR TITLE
proposition: Use os.tmpdir as socket file directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ npm install tg-cli-node
 Create `config.js` with:
 ```javascript
 const path = require('path');
+const os = require('os');
 
 module.exports = {
     telegram_cli_path: path.join(__dirname, 'tg/bin/telegram-cli'), //path to tg-cli (see https://github.com/vysheng/tg)
-    telegram_cli_socket_path: path.join(__dirname, 'socket'), // path for socket file
+    telegram_cli_socket_path: path.join( os.tmpdir(), 'socket'), // path for socket file
     server_publickey_path: path.join(__dirname, 'tg/tg-server.pub'), // path to server key (traditionally, in %tg_cli_path%/tg-server.pub)
 }
 ```


### PR DESCRIPTION
In my opinion it is better to keep socket in tmp dir. It have to be on DrvFs on windows WSL.
https://github.com/Microsoft/WSL/issues/2137